### PR TITLE
fix: eva error

### DIFF
--- a/utils/app/chatGPT.ts
+++ b/utils/app/chatGPT.ts
@@ -133,7 +133,8 @@ export const gradedMultipleCaseUsingChatGPT = async (
     return scores.reduce((a, b) => a + b);
   }
   else {
-    throw new Error('No scores were extracted from ChatGPTResponse');
+    console.error('No scores were extracted from ChatGPTResponse');
+    return 0;
   }
 }
 


### PR DESCRIPTION
JSONの採点のときに全て採点できないフォーマットの結果の場合エラーを吐き出す処理の修正